### PR TITLE
Fix password not getting passed in steam2backloggery.bat

### DIFF
--- a/steam2backloggery.bat
+++ b/steam2backloggery.bat
@@ -3,6 +3,6 @@ set BL_NAME=backloggery username
 set BL_PASS=backloggery password
 set EDITOR=notepad
 
-java -jar bltool.jar --steam-name "%STEAM_NAME%" --bl-name "%BL_NAME%" --bl-pass "%BL_PASS" --filter --from steam --to text --output games.txt
+java -jar bltool.jar --steam-name "%STEAM_NAME%" --bl-name "%BL_NAME%" --bl-pass "%BL_PASS%" --filter --from steam --to text --output games.txt
 %EDITOR% games.txt
-java -jar bltool.jar --bl-name "%BL_NAME%" --bl-pass "%BL_PASS" --from text --to edn --input games.txt --output games.edn
+java -jar bltool.jar --bl-name "%BL_NAME%" --bl-pass "%BL_PASS%" --from text --to edn --input games.txt --output games.edn


### PR DESCRIPTION
The `BL_PASS` variable was missing the last `%`
