### PR TITLE
Add installation instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Download the latest release and unzip it. At this point you can import your game
 
 If you want to build from source, it uses Leiningen, the standard Clojure build tool; use `lein uberjar` to build or `lein run` to run. To create a release zip, use `./release.sh <version>`.
 
+### Homebrew on Mac OS X
+
+You can also install bltool using the [Homebrew](http://brew.sh/) package manager for Mac OS X.
+
+```
+$ brew update
+$ brew install bltool
+```
+
+To upgrade bltool in the future, just use `upgrade` instead of `install`.
+
 ## Usage
 
     Usage: bltool <command> [<args>]


### PR DESCRIPTION
I added a [Homebrew formula](https://github.com/Homebrew/homebrew/commit/f81b2a7f1cf5ff7f8e88d51829e9944d8b4a5dc8) for bltool, so Mac OS X users can now install the latest release with `brew install bltool`, or pull from `master` with `brew install --HEAD bltool`.